### PR TITLE
fix a wrong-number-of-arguments error

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -376,9 +376,9 @@
   (add-hook 'post-self-insert-hook 'rime--redisplay nil t))
 
 (defun rime-mode--uninit ()
-  (setq-local rime--backspace-fallback nil
-              rime--return-fallback nil
-              rime--escape-fallback nil)
+  (setq-local rime--backspace-fallback nil)
+  (setq-local rime--return-fallback nil)
+  (setq-local rime--escape-fallback nil)
   (remove-hook 'post-self-insert-hook 'rime--redisplay))
 
 (define-minor-mode rime-mode


### PR DESCRIPTION
Debugger entered--Lisp error: (wrong-number-of-arguments (2 . 2) 6)
  #f(compiled-function (var val) "Set variable VAR to value VAL in current buffer." #<bytecode 0x40090cf3>)(rime--backspace-fallback nil rime--return-fallback nil rime--escape-fallback nil)
  (setq-local rime--backspace-fallback nil rime--return-fallback nil rime--escape-fallback nil)
  rime-mode--uninit()
  (if rime-mode (rime-mode--init) (rime-mode--uninit))
  (let ((last-message (current-message))) (setq rime-mode (if (eq arg (quote toggle)) (not rime-mode) (> (prefix-numeric-value arg) 0))) (if rime-mode (rime-mode--init) (rime-mode--uninit)) (run-hooks (quote rime-mode-hook) (if rime-mode (quote rime-mode-on-hook) (quote rime-mode-off-hook))) (if (called-interactively-p (quote any)) (progn nil (if (and (current-message) (not (equal last-message (current-message)))) nil (let ((local " in current buffer")) (message "Rime mode %sabled%s" (if rime-mode "en" "dis") local))))))
  rime-mode(-1)
  (if (liberime-get-context) (rime-mode 1) (rime-mode -1))
  rime--refresh-mode-state()
  (unwind-protect (cond ((and (not context) (not commit) (not preedit)) (if rime--prev-preedit (progn (liberime-clear-composition) (let ((--dolist-tail-- ...)) (while --dolist-tail-- (let ... ... ...))) (rime--redisplay) (setq preedit (alist-get (quote preedit) (alist-get ... ...)))) (liberime-clear-composition) (list key))) (commit (rime--clear-overlay) (mapcar (quote identity) commit)) (t (rime--redisplay))) (rime--refresh-mode-state) (set (make-local-variable (quote rime--prev-preedit)) preedit))
  (let* ((context (liberime-get-context)) (preedit (alist-get (quote preedit) (alist-get (quote composition) context))) (commit (liberime-get-commit))) (unwind-protect (cond ((and (not context) (not commit) (not preedit)) (if rime--prev-preedit (progn (liberime-clear-composition) (let (...) (while --dolist-tail-- ...)) (rime--redisplay) (setq preedit (alist-get ... ...))) (liberime-clear-composition) (list key))) (commit (rime--clear-overlay) (mapcar (quote identity) commit)) (t (rime--redisplay))) (rime--refresh-mode-state) (set (make-local-variable (quote rime--prev-preedit)) preedit)))
  (progn (let* ((context (liberime-get-context)) (preedit (alist-get (quote preedit) (alist-get (quote composition) context))) (commit (liberime-get-commit))) (unwind-protect (cond ((and (not context) (not commit) (not preedit)) (if rime--prev-preedit (progn (liberime-clear-composition) (let ... ...) (rime--redisplay) (setq preedit ...)) (liberime-clear-composition) (list key))) (commit (rime--clear-overlay) (mapcar (quote identity) commit)) (t (rime--redisplay))) (rime--refresh-mode-state) (set (make-local-variable (quote rime--prev-preedit)) preedit))))
  (unwind-protect (progn (let* ((context (liberime-get-context)) (preedit (alist-get (quote preedit) (alist-get (quote composition) context))) (commit (liberime-get-commit))) (unwind-protect (cond ((and (not context) (not commit) (not preedit)) (if rime--prev-preedit (progn ... ... ... ...) (liberime-clear-composition) (list key))) (commit (rime--clear-overlay) (mapcar (quote identity) commit)) (t (rime--redisplay))) (rime--refresh-mode-state) (set (make-local-variable (quote rime--prev-preedit)) preedit)))) (if modified nil (restore-buffer-modified-p nil)))
  (let* ((modified (buffer-modified-p)) (buffer-undo-list t) (inhibit-read-only t) (inhibit-modification-hooks t)) (unwind-protect (progn (let* ((context (liberime-get-context)) (preedit (alist-get (quote preedit) (alist-get ... context))) (commit (liberime-get-commit))) (unwind-protect (cond ((and ... ... ...) (if rime--prev-preedit ... ... ...)) (commit (rime--clear-overlay) (mapcar ... commit)) (t (rime--redisplay))) (rime--refresh-mode-state) (set (make-local-variable (quote rime--prev-preedit)) preedit)))) (if modified nil (restore-buffer-modified-p nil))))
  (if (and (not (rime--should-enable-p)) (not (liberime-get-context))) (list key) (liberime-process-key key) (let* ((modified (buffer-modified-p)) (buffer-undo-list t) (inhibit-read-only t) (inhibit-modification-hooks t)) (unwind-protect (progn (let* ((context (liberime-get-context)) (preedit (alist-get ... ...)) (commit (liberime-get-commit))) (unwind-protect (cond (... ...) (commit ... ...) (t ...)) (rime--refresh-mode-state) (set (make-local-variable ...) preedit)))) (if modified nil (restore-buffer-modified-p nil)))))
  rime-input-method(44)