### PR TITLE
移除 rime-toggle

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,8 +18,8 @@
              :fetcher github
              :repo "DogLooksGood/emacs-rime"
              :files ("rime.el"))
-    :bind
-    (("C-\\" . 'rime-toggle)))
+    :custom (default-input-method "rime")
+    )
 #+END_SRC
 
 * 设置输入中发送到 Rime 的组合键。
@@ -43,10 +43,7 @@
 | ~minibuffer~ | 在minibuffer中展示， 推荐使用的方式                   |
 | ~message~    | 直接使用 ~message~ 输出，兼容控制 ~minibuffer~ 内容的插件 |
 | ~popup~      | 使用 ~popup.el~ 展示跟随的候选                          |
-
-#+BEGIN_SRC emacs-lisp
-  (setq rime-input-editable nil)
-#+END_SRC
+| ~posframe~   | 使用 ~posframe~ 展示跟随的候选                          |
 
 * 用于展示的提示符
 

--- a/rime.el
+++ b/rime.el
@@ -456,6 +456,11 @@ minibuffer 原来显示的信息和 rime 选词框整合在一起显示
 ;;;###autoload
 (register-input-method "rime" "euc-cn" 'rime-activate rime-title)
 
+;;;###autoload
+(defun rime-toggle ()
+  (interactive)
+  (message "`rime-toggle' is deprecated, use `toggle-input-method' instead"))
+
 (provide 'rime)
 
 ;;; rime.el ends here


### PR DESCRIPTION
允许直接使用set-input-method 选择 rime,不再需要 rime-toggle