### PR TITLE
Fix: define-key "<return>" same as "RET"

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -810,6 +810,7 @@ Argument NAME ignored."
   (let ((keymap (make-sparse-keymap)))
     (define-key keymap (kbd "DEL") 'rime--backspace)
     (define-key keymap (kbd "<backspace>") 'rime--backspace)
+    (define-key keymap (kbd "<return>") 'rime--return)
     (define-key keymap (kbd "RET") 'rime--return)
     (define-key keymap (kbd "<escape>") 'rime--escape)
     keymap)


### PR DESCRIPTION
On GUI emacs, enter key is "<return>"; on TUI emacs, it is "RET".


----

#