### PR TITLE
Fix: mustn't use 'file-name-as-directory'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ ifeq ($(LIBRIME_DYLIB), .dylib)
 endif
 
 ifdef LIBRIME_ROOT
-	ENV      = C_INCLUDE_PATH=${LIBRIME_ROOT}include/
-	LDFLAGS  += -L ${LIBRIME_ROOT}lib/ -Wl,-rpath ${LIBRIME_ROOT}lib/ -lrime
+	ENV      = C_INCLUDE_PATH=${LIBRIME_ROOT}/include/
+	LDFLAGS  += -L ${LIBRIME_ROOT}/lib/ -Wl,-rpath ${LIBRIME_ROOT}/lib/ -lrime
 else
 	ENV      =
 	LDFLAGS  += -lrime

--- a/rime.el
+++ b/rime.el
@@ -750,11 +750,11 @@ You can customize the color with `rime-indicator-face' and `rime-indicator-dim-f
    (mapcar
     (lambda (arg)
       (if (symbol-value (car arg))
-          (format "%s=%s" (cdr arg) (file-name-as-directory (symbol-value (car arg))))
+          (format "%s=%s" (cdr arg) (symbol-value (car arg)))
         ""))
-   '((rime-librime-root . "LIBRIME_ROOT")
-     (rime-emacs-module-header-root . "EMACS_MODULE_HEADER_ROOT")
-     (module-file-suffix . "LIBRIME_DYLIB")))
+    '((rime-librime-root . "LIBRIME_ROOT")
+      (rime-emacs-module-header-root . "EMACS_MODULE_HEADER_ROOT")
+      (module-file-suffix . "LIBRIME_DYLIB")))
    " "))
 
 (defun rime-compile-module ()


### PR DESCRIPTION
紧急：在 rime.el 中使用 `file-name-as-directory` 处理生成环境ENV变量，其它几个本身都是目录没问题，但是module-file-suffix是文件扩展名，如果用 `file-name-as-directory` 处理就会把要生成的文件名变成 "librime-emacs.so/" 或 "librime-emacs.dylib/" ，而且也无法正确添加编译选项 "-shared" 或 "-dynamiclib" ，从而造成编译失败。