### PR TITLE
Migrate all predicates.

### DIFF
--- a/README.org
+++ b/README.org
@@ -67,10 +67,10 @@ You can download the release.
 #+END_SRC
 #+html: </details>
 
-*NOTE*: If you are on MacOS or don't have librime in standard path, 
+*NOTE*: If you are on MacOS or don't have librime in standard path,
 you *MUST* specify ~rime-librime-root~.
 
-Put following in the ~:custom~ section. 
+Put following in the ~:custom~ section.
 
 (Assuming you unzip librime to ~/.emacs.d/librime)
 
@@ -152,23 +152,47 @@ Following is a example to use ascii mode in ~evil-normal-state~ or when cursor i
 
 - ~rime-predicate-after-alphabet-char-p~
 
-  Only alphabet character can be entered after an alphabet character.
+  After an alphabet character (must beginning with letter [a-zA-Z]).
+
+- ~rime-predicate-after-ascii-char-p~
+
+  After any alphabet character.
 
 - ~rime-predicate-prog-in-code-p~
 
-  In the ~prog-mode~ and ~conf-mode~, Chinese characters can be entered only in comments and quotes.
+  On ~prog-mode~ and ~conf-mode~, not in comments and quotes.
 
 - ~rime-predicate-evil-mode-p~
 
-  Only alphabet character can be entered in the non-editing state of ~evil-mode~.
+  In the non-editing state of ~evil-mode~.
+
+- ~rime-predicate-current-input-punctuation-p~
+
+  When entering punctuation.
+
+- ~rime-predicate-punctuation-after-space-cc-p~
+
+  When entering punctuation after a Chinese character appended with whitespaces.
+
+- ~rime-predicate-punctuation-after-ascii-p~
+
+  When entering punctuation after an ascii character.
 
 - ~rime-predicate-punctuation-line-begin-p~
 
-  Automatically switch to English punctuation when entering punctuation at the beginning of the line.
+  When entering punctuation at the beginning of the line.
 
-- ~rime-predicate-auto-english-p~
+- ~rime-predicate-space-after-ascii-p~
 
-  When entering characters, automatically switch Chinese/English with space as boundary,
+  After an ascii character appended with whitespaces.
+
+- ~rime-predicate-space-after-cc-p~
+
+  After a Chinese character appended with whitespaces.
+
+- ~rime-predicate-current-uppercase-letter-p~
+
+  When entering a uppercase letter.
 
 #+html: </details>
 

--- a/README.org
+++ b/README.org
@@ -49,7 +49,7 @@ You can download the release.
     :straight (rime :type git
                     :host github
                     :repo "DogLooksGood/emacs-rime"
-                    :files ("rime.el" "Makefile" "lib.c"))
+                    :files ("*.el" "Makefile" "lib.c"))
     :custom
     (default-input-method "rime"))
 #+END_SRC
@@ -61,7 +61,7 @@ You can download the release.
   (use-package rime
     :quelpa (rime :fetcher github
                   :repo "DogLooksGood/emacs-rime"
-                  :files ("rime.el" "Makefile" "lib.c"))
+                  :files ("*.el" "Makefile" "lib.c"))
     :custom
     (default-input-method "rime"))
 #+END_SRC

--- a/README_CN.org
+++ b/README_CN.org
@@ -41,7 +41,7 @@ Emacs Rime 已发布到 Melpa 。
     :straight (rime :type git
                     :host github
                     :repo "DogLooksGood/emacs-rime"
-                    :files ("rime.el" "Makefile" "lib.c"))
+                    :files ("*.el" "Makefile" "lib.c"))
     :custom
     (default-input-method "rime"))
 #+END_SRC
@@ -53,7 +53,7 @@ Emacs Rime 已发布到 Melpa 。
   (use-package rime
     :quelpa (rime :fetcher github
                   :repo "DogLooksGood/emacs-rime"
-                  :files ("rime.el" "Makefile" "lib.c"))
+                  :files ("*.el" "Makefile" "lib.c"))
     :custom
     (default-input-method "rime"))
 #+END_SRC

--- a/README_CN.org
+++ b/README_CN.org
@@ -119,7 +119,9 @@ Emacs Rime 已发布到 Melpa 。
 支持的内容参照 [[https://github.com/tumashu/posframe/blob/master/posframe.el#L212][posframe]] 。
 
 * 临时英文模式的切换
-如果使用模式编辑，或是需要在一些特定的场景下自动使用英文，可以 ~rime-disable-predicates~ 。
+如果使用模式编辑，或是在一些特定的场景下需要自动使用英文，可以设
+置~rime-disable-predicates~ ， ~rime-disable-predicates~ 的值是一个断言列表，
+当其中有任何一个断言的值 **不是** nil 时，会自动使用英文。
 
 一个在 ~evil-normal-state~ 中、在英文字母后面以及代码中自动使用英文的例子。
 
@@ -130,17 +132,54 @@ Emacs Rime 已发布到 Melpa 。
           rime-predicate-prog-in-code-p))
 #+END_SRC
 
-目前可用的断言函数有：
+#+html: <details>
+#+html: <summary>目前可用的断言函数</summary>
+
 - ~rime-predicate-after-alphabet-char-p~
-  在英文字符后继续输入英文
+
+  在英文字符串之后（必须为以字母开头的英文字符串）
+
+- ~rime-predicate-after-ascii-char-p~
+
+  任意英文字符后
+
 - ~rime-predicate-prog-in-code-p~
-  在 ~prog-mode~ 和 ~conf-mode~ 里只有注释和引号内可以输入中文
+
+  在 ~prog-mode~ 和 ~conf-mode~ 中除了注释和引号内字符串之外的区域
+
 - ~rime-predicate-evil-mode-p~
-  在 ~evil-mode~ 的非编辑状态下输入为英文方式
+
+  在 ~evil-mode~ 的非编辑状态下
+
+- ~rime-predicate-current-input-punctuation-p~
+
+  当要输入的是符号时
+
+- ~rime-predicate-punctuation-after-space-cc-p~
+
+  当要在中文字符且有空格之后输入符号时
+
+- ~rime-predicate-punctuation-after-ascii-p~
+
+  当要在任意英文字符之后输入符号时
+
 - ~rime-predicate-punctuation-line-begin-p~
-  在行首输入符号时自动转为英文
-- ~rime-predicate-auto-english-p~
-  以空格为界，自动切换中英文
+
+  在行首要输入符号时
+
+- ~rime-predicate-space-after-ascii-p~
+
+  在任意英文字符且有空格之后
+
+- ~rime-predicate-space-after-cc-p~
+
+  在中文字符且有空格之后
+
+- ~rime-predicate-current-uppercase-letter-p~
+
+  将要输入的为大写字母时
+
+#+html: </details>
 
 ** 可提示临时英文状态的提示符
 

--- a/rime-predicates.el
+++ b/rime-predicates.el
@@ -1,0 +1,145 @@
+;;; rime-predicates.el --- Predicates for emacs-rime to automatic input Chinese/English.
+;;; cnsunyour/chinese/rime-predicates.el -*- lexical-binding: t; -*-
+
+
+;;; Commentary:
+;;
+;; With these predicates, You can continuously input mixed Chinese and English
+;; text with punctuation, only using the Spacebar and the Enter key to assist,
+;; without the extra switch key.
+;;
+
+;;; Code:
+
+(defun rime-predicate-after-alphabet-char-p ()
+  "If the cursor is after a alphabet character.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (> (point) (save-excursion (back-to-indentation) (point)))
+       (let ((string (buffer-substring (point) (line-beginning-position))))
+         (string-match-p "[a-zA-Z][0-9\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]*$" string))))
+
+(defun rime-predicate-after-ascii-char-p ()
+  "If the cursor is after a ascii character.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (> (point) (save-excursion (back-to-indentation) (point)))
+       (let ((string (buffer-substring (point) (line-beginning-position))))
+         (string-match-p "[a-zA-Z0-9\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]$" string))))
+
+(defun rime-predicate-prog-in-code-p ()
+  "If cursor is in code.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (derived-mode-p 'prog-mode 'conf-mode)
+       (not (or (nth 3 (syntax-ppss))
+                (nth 4 (syntax-ppss))))))
+
+(defun rime-predicate-evil-mode-p ()
+  "Detect whether the current buffer is in `evil' state.
+
+Include `evil-normal-state' ,`evil-visual-state' ,
+`evil-motion-state' , `evil-operator-state'.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (fboundp 'evil-mode)
+       (or (evil-normal-state-p)
+           (evil-visual-state-p)
+           (evil-motion-state-p)
+           (evil-operator-state-p))))
+
+(defun rime-predicate-current-input-punctuation-p ()
+  "If the current charactor entered is a punctuation.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and rime--current-input-key
+       (or (and (<= #x21 rime--current-input-key) (<= rime--current-input-key #x2f))
+           (and (<= #x3a rime--current-input-key) (<= rime--current-input-key #x40))
+           (and (<= #x5b rime--current-input-key) (<= rime--current-input-key #x60))
+           (and (<= #x7b rime--current-input-key) (<= rime--current-input-key #x7f)))))
+
+(defun rime-predicate-punctuation-after-space-cc-p ()
+  "If input a punctuation after a Chinese charactor with whitespace.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (> (point) (save-excursion (back-to-indentation) (point)))
+       (rime-predicate-current-input-punctuation-p)
+       (let ((string (buffer-substring (point) (line-beginning-position))))
+         (string-match-p "\\cc +$" string))))
+
+(defun rime-predicate-punctuation-after-ascii-p ()
+  "If input a punctuation after a ascii charactor with whitespace.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (rime-predicate-current-input-punctuation-p)
+       (rime-predicate-after-ascii-char-p)))
+
+(defun rime-predicate-punctuation-line-begin-p ()
+  "Enter half-width punctuation at the beginning of the line.
+
+  Detect whether the current cursor is at the beginning of a
+  line and the character last inputted is symbol.
+
+  Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (<= (point) (save-excursion (back-to-indentation) (point)))
+       (rime-predicate-current-input-punctuation-p)))
+
+(defun rime-predicate-auto-english-p ()
+  "Auto switch Chinese/English input state.
+
+  After activating this probe function, use the following rules
+  to automatically switch between Chinese and English input:
+
+     1. When the current character is an English
+  character (excluding spaces), enter the next character as an
+  English character.
+    2. When the current character is a Chinese character or the
+  input character is a beginning character, the input character is
+  a Chinese character.
+     3. With a single space as the boundary, automatically switch
+  between Chinese and English characters.
+
+  That is, a sentence of the form \"我使用 emacs 编辑此函数\"
+  automatically switches between Chinese and English input methods.
+
+  Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and (> (point) (save-excursion (back-to-indentation) (point)))
+       (let ((string (buffer-substring (point) (line-beginning-position))))
+         (if (string-match-p " +$" string)
+             (string-match-p "\\cc +$" string)
+           (not (string-match-p "\\cc$" string))))))
+
+(defun rime-predicate-space-after-ascii-p ()
+  "If cursor is after a whitespace which follow a ascii character."
+  (and (> (point) (save-excursion (back-to-indentation) (point)))
+       (let ((string (buffer-substring (point) (line-beginning-position))))
+         (and (string-match-p " +$" string)
+              (not (string-match-p "\\cc +$" string))))))
+
+(defun rime-predicate-space-after-cc-p ()
+  "If cursor is after a whitespace which follow a non-ascii character."
+  (and (> (point) (save-excursion (back-to-indentation) (point)))
+       (let ((string (buffer-substring (point) (line-beginning-position))))
+         (string-match-p "\\cc +$" string))))
+
+(defun rime-predicate-current-uppercase-letter-p ()
+  "If the current charactor entered is a uppercase letter.
+
+Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
+  (and rime--current-input-key
+       (>= rime--current-input-key ?A)
+       (<= rime--current-input-key ?Z)))
+
+
+;; Obsoleted functions:
+(define-obsolete-function-alias 'rime--after-alphabet-char-p 'rime-predicate-after-alphabet-char-p "2020-03-26")
+(define-obsolete-function-alias 'rime--prog-in-code-p 'rime-predicate-prog-in-code-p "2020-03-26")
+(define-obsolete-function-alias 'rime--evil-mode-p 'rime-predicate-evil-mode-p "2020-03-26")
+(define-obsolete-function-alias 'rime--punctuation-line-begin-p 'rime-predicate-punctuation-line-begin-p "2020-03-26")
+(define-obsolete-function-alias 'rime--auto-english-p 'rime-predicate-auto-english-p "2020-03-26")
+(make-obsolete 'rime-predicate-auto-english-p "please use other predicates instead of it." "2020-03-29")
+
+
+(provide 'rime-predicates)
+
+;;; rime-predicates.el ends here

--- a/rime.el
+++ b/rime.el
@@ -345,143 +345,6 @@ Defaults to `user-emacs-directory'/rime/"
 Currently only Shift, Control, Meta is supported as modifiers.
 Each keybinding in this list, will be bound to `rime-send-keybinding' in `rime-active-mode-map'.")
 
-(defun rime-predicate-after-alphabet-char-p ()
-  "If the cursor is after a alphabet character.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (looking-back "[a-zA-Z][0-9\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]*" 1))
-
-(defun rime--after-alphabet-char-p ()
-  (message "`rime--after-alphabet-char-p' was renamed to `rime-predicate-after-alphabet-char-p'; use that instead.")
-  (rime-predicate-after-alphabet-char-p))
-(make-obsolete 'rime--after-alphabet-char-p 'rime-predicate-after-alphabet-char-p "2020-03-26")
-
-(defun rime-predicate-after-ascii-char-p ()
-  "If the cursor is after a ascii character.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (and (> (point) (save-excursion (back-to-indentation) (point)))
-       (looking-back "[a-zA-Z0-9\x21-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]" 1)))
-
-(defun rime-predicate-prog-in-code-p ()
-  "If cursor is in code.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (when (derived-mode-p 'prog-mode 'conf-mode)
-    (not (or (nth 3 (syntax-ppss))
-             (nth 4 (syntax-ppss))))))
-
-(defun rime--prog-in-code-p ()
-  (message "`rime--prog-in-code-p' was renamed to `rime-predicate-prog-in-code-p'; use that instead.")
-  (rime-predicate-prog-in-code-p))
-(make-obsolete 'rime--prog-in-code-p 'rime-predicate-prog-in-code-p "2020-03-26")
-
-(defun rime-predicate-evil-mode-p ()
-  "Determines whether the current buffer is in `evil' state.
-
-Include `evil-normal-state' ,`evil-visual-state' ,
-`evil-motion-state' , `evil-operator-state'.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (when (fboundp 'evil-mode)
-    (or (evil-normal-state-p)
-        (evil-visual-state-p)
-        (evil-motion-state-p)
-        (evil-operator-state-p))))
-
-(defun rime--evil-mode-p ()
-  (message "`rime--evil-mode-p' was renamed to `rime-predicate-evil-mode-p'; use that instead.")
-  (rime-predicate-evil-mode-p))
-(make-obsolete 'rime--evil-mode-p 'rime-predicate-evil-mode-p "2020-03-26")
-
-(defun rime-predicate-current-input-punctuation-p ()
-  "If the current charactor entered is a punctuation.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (and rime--current-input-key
-       (or (and (<= #x21 rime--current-input-key) (<= rime--current-input-key #x2f))
-           (and (<= #x3a rime--current-input-key) (<= rime--current-input-key #x40))
-           (and (<= #x5b rime--current-input-key) (<= rime--current-input-key #x60))
-           (and (<= #x7b rime--current-input-key) (<= rime--current-input-key #x7f)))))
-
-(defun rime-predicate-punctuation-line-begin-p ()
-  "Enter half-width punctuation at the beginning of the line.
-
-  Determines whether the current cursor is at the beginning of a
-  line and the character last inputted is symbol.
-
-  Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (and (<= (point) (save-excursion (back-to-indentation) (point)))
-       (rime-predicate-current-input-punctuation-p)))
-
-(defun rime--punctuation-line-begin-p ()
-  (message "`rime--punctuation-line-begin-p' was renamed to `rime-predicate-punctuation-line-begin-p'; use that instead.")
-  (rime-predicate-punctuation-line-begin-p))
-(make-obsolete 'rime--punctuation-line-begin-p 'rime-predicate-punctuation-line-begin-p "2020-03-26")
-
-(defun rime-predicate-punctuation-after-space-cc-p ()
-  "If input a punctuation after a Chinese charactor with whitespace.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'.\""
-  (and (> (point) (save-excursion (back-to-indentation) (point)))
-       (rime-predicate-current-input-punctuation-p)
-       (looking-back "\\cc +" 2)))
-
-(defun rime-predicate-punctuation-after-ascii-p ()
-  "If input a punctuation after a ascii charactor with whitespace.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (and (rime-predicate-current-input-punctuation-p)
-       (rime-predicate-after-ascii-char-p)))
-
-(defun rime-predicate-auto-english-p ()
-  "Auto switch Chinese/English input state.
-
-  After activating this probe function, use the following rules
-  to automatically switch between Chinese and English input:
-
-     1. When the current character is an English
-  character (excluding spaces), enter the next character as an
-  English character.
-    2. When the current character is a Chinese character or the
-  input character is a beginning character, the input character is
-  a Chinese character.
-     3. With a single space as the boundary, automatically switch
-  between Chinese and English characters.
-
-  That is, a sentence of the form \"我使用 emacs 编辑此函数\"
-  automatically switches between Chinese and English input methods.
-
-  Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (if (> (point) (save-excursion (back-to-indentation) (point)))
-      (if (looking-back " +" 1)
-          (looking-back "\\cc +" 2)
-        (not (looking-back "\\cc" 1)))))
-
-(defun rime--auto-english-p ()
-  (message "`rime--auto-english-p' was renamed to `rime-predicate-auto-english-p'; use that instead.")
-  (rime-predicate-auto-english-p))
-(make-obsolete 'rime--auto-english-p 'rime-predicate-auto-english-p "2020-03-26")
-
-(defun rime-predicate-space-after-ascii-p ()
-  "If cursor is after a whitespace which follow a ascii character."
-  (and (> (point) (save-excursion (back-to-indentation) (point)))
-       (looking-back " +" 1)
-       (not (looking-back "\\cc +" 1))))
-
-(defun rime-predicate-space-after-cc-p ()
-  "If cursor is after a whitespace which follow a non-ascii character."
-  (and (> (point) (save-excursion (back-to-indentation) (point)))
-       (looking-back "\\cc +" 2)))
-
-(defun rime-predicate-current-uppercase-letter-p ()
-  "If the current charactor entered is a uppercase letter.
-
-Can be used in `rime-disable-predicates' and `rime-inline-predicates'."
-  (and rime--current-input-key
-       (>= rime--current-input-key ?A)
-       (<= rime--current-input-key ?Z)))
-
 (defun rime--should-enable-p ()
   "If key event should be handled by input-method."
   (or rime--temporarily-ignore-predicates
@@ -1025,6 +888,9 @@ Will resume when finish composition."
                             (car (-find (lambda (arg) (equal (cadr arg) schema-name)) schema-list)))
                     rime-user-data-dir)))
     (message "Rime is not activated.")))
+
+
+(require 'rime-predicates)
 
 (provide 'rime)
 


### PR DESCRIPTION
Migrate all predicates to a standalone `rime-predicates.el` file.
Optimized all funcall "looking-back".
Make some predicates obsoleted:
  - rime--after-alphabet-char-p
  - rime--prog-in-code-p
  - rime--evil-mode-p
  - rime--punctuation-line-begin-p
  - rime--auto-english-p
  - rime-predicate-auto-english-p