### PR TITLE
fix: Move lexical-binding local variable to the first line

### DIFF
--- a/rime-predicates.el
+++ b/rime-predicates.el
@@ -1,5 +1,5 @@
-;;; rime-predicates.el --- Predicates for emacs-rime to automatic input Chinese/English.
-;;; cnsunyour/chinese/rime-predicates.el -*- lexical-binding: t; -*-
+;;; rime-predicates.el --- Predicates for emacs-rime to automatic input Chinese/English. -*- lexical-binding: t; -*-
+;;; cnsunyour/chinese/rime-predicates.el
 
 
 ;;; Commentary:

--- a/rime.el
+++ b/rime.el
@@ -1,6 +1,5 @@
-;;; rime.el --- Rime input method
-;; -*- lexical-binding: t -*-
-;;
+;;; rime.el --- Rime input method -*- lexical-binding: t -*-
+
 ;; Author: Shi Tianshu
 ;; Keywords: convenience, input-method
 ;; Package-Requires: ((emacs "26.3") (dash "2.12.0") (cl-lib "0.6.1") (popup "0.5.3") (posframe "0.1.0"))


### PR DESCRIPTION
According to the document of `lexical-binding`, the file local variable to enable `lexical-binding` for a file must be put at the first line of a file.

See: https://github.com/emacs-mirror/emacs/blob/master/src/lread.c#L4999