### PR TITLE
:sparkles: add rime-inline-ascii-holder

### DIFF
--- a/README_CN.org
+++ b/README_CN.org
@@ -283,6 +283,11 @@ Emacs Rime 已发布到 Melpa 。
   (define-key rime-active-mode-map (kbd "M-j") 'rime-inline-ascii)
 #+end_src
 
+** 临时英文中阻止标点直接上屏
+#+begin_src emacs-lisp
+  (setq rime-inline-ascii-holder ?x)      ; Any single character that not trigger auto commit
+#+end_src
+
 ** 断言成立时的强制中文模式
 使用 ~rime-force-enable~ 来临时强制使用强制中文模式（即无视 ~rime-disable-predicates~ 中的规则），
 在 *一次输入行为* 或 *取消输入* 之后会自动关闭强制中文模式。


### PR DESCRIPTION
使用一个字符来阻止临时英文触发时，中文标点直接上屏。