### PR TITLE
Look for rime-data in "/usr/local/share" rather than "/usr/share/local"

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -308,7 +308,7 @@ Defaults to `user-emacs-directory'/rime/"
                     dir)))
               (if (fboundp 'xdg-data-dirs)
                   (xdg-data-dirs)
-                '("/usr/share/local" "/usr/share"))))
+                '("/usr/local/share" "/usr/share"))))
     ('darwin
      "/Library/Input Methods/Squirrel.app/Contents/SharedSupport")
     ('windows-nt


### PR DESCRIPTION
`/usr/share/local` 不符合[FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)规范。正确的路径是 `/usr/local/share`。