### PR TITLE
better Integration with evil-escape

### DIFF
--- a/README.org
+++ b/README.org
@@ -484,40 +484,37 @@ patch:
 #+html: <details>
 #+html: <summary>如何结合evil-escape一起使用？</summary>
 
-在你的配置中添加如下内容，即可用[[https://github.com/syl20bnr/evil-escape][evil-escape]]的按键回到normal模式。不过请注意，此操作
-会丢弃全部正在输入中的内容。
+在你的配置中添加如下内容，即可在当前没有输入内容（没有preedit overlay）的情况
+下，用[[https://github.com/syl20bnr/evil-escape][evil-escape]]的按键回到normal模式。
 
 #+BEGIN_SRC emacs-lisp
-(defun rime-evil-escape-advice (orig-fun key)
-  "advice for `rime-input-method' to make it work together with `evil-escape'.
-Mainly modified from `evil-escape-pre-command-hook'"
-  (when (featurep 'evil-escape)
-    (let* (
-           (fkey (elt evil-escape-key-sequence 0))
-           (skey (elt evil-escape-key-sequence 1))
-           (evt (read-event nil nil evil-escape-delay))
-           )
-      (cond
-       ((and (characterp evt)
-             (or (and (char-equal key fkey) (char-equal evt skey))
-                 (and evil-escape-unordered-key-sequence
-                      (char-equal key skey) (char-equal evt fkey))))
-        (evil-repeat-stop)
-        ;; need 2 escape: one escapes from input method, the other one escapes from else
-        (rime--escape)
-        (evil-normal-state)
-        (let ((esc-fun (evil-escape-func)))
-              (when esc-fun
-                (setq this-command esc-fun)
-                (setq this-original-command esc-fun))))
-       ((null evt) (apply orig-fun (list key)))
-       (t
-        (apply orig-fun (list key))
-        (if (numberp evt)
-            (apply orig-fun (list evt))
-          (setq unread-command-events (append unread-command-events (list evt)))))))))
+  (defun rime-evil-escape-advice (orig-fun key)
+    "advice for `rime-input-method' to make it work together with `evil-escape'.
+	Mainly modified from `evil-escape-pre-command-hook'"
+    (if rime--preedit-overlay
+	;; if `rime--preedit-overlay' is non-nil, then we are editing something, do not abort 
+	(apply orig-fun (list key))
+      (when (featurep 'evil-escape)
+	(let* (
+	       (fkey (elt evil-escape-key-sequence 0))
+	       (skey (elt evil-escape-key-sequence 1))
+	       (evt (read-event nil nil evil-escape-delay))
+	       )
+	  (cond
+	   ((and (characterp evt)
+		 (or (and (char-equal key fkey) (char-equal evt skey))
+		     (and evil-escape-unordered-key-sequence
+			  (char-equal key skey) (char-equal evt fkey))))
+	    (evil-repeat-stop)
+	    (evil-normal-state))
+	   ((null evt) (apply orig-fun (list key)))
+	   (t
+	    (apply orig-fun (list key))
+	    (if (numberp evt)
+		(apply orig-fun (list evt))
+	      (setq unread-command-events (append unread-command-events (list evt))))))))))
 
-(advice-add 'rime-input-method :around #'rime-evil-escape-advice)
+  (advice-add 'rime-input-method :around #'rime-evil-escape-advice)
 #+END_SRC
 
 #+html: </details>

--- a/README_EN.org
+++ b/README_EN.org
@@ -343,14 +343,14 @@ This can temporarily solve the problem of `posframe` occasionally
 #+html: </details>
 
 #+html: <details>
-#+html: <summary><b>Want a pure emacs input method without ~librime~?</b></summary><br/>
+#+html: <summary><b>Want a pure emacs input method without <code>librime</code>?</b></summary><br/>
 
 Maybe, you need [[https://github.com/tumashu/pyim][pyim]].
 
 #+html: </details>
 
 #+html: <details>
-#+html: <summary><b>How to integrate this with ~evil-escape~?</b></summary>
+#+html: <summary><b>How to integrate this with <code>evil-escape</code>?</b></summary>
 
 Add the following code snippet in your configuration files, then you can use [[https://github.com/syl20bnr/evil-escape][evil-escape]]
 to return to normal state when having nothing in editing(no preedit overlay).

--- a/README_EN.org
+++ b/README_EN.org
@@ -343,50 +343,45 @@ This can temporarily solve the problem of `posframe` occasionally
 #+html: </details>
 
 #+html: <details>
-#+html: <summary><b>Want a pure emacs input method without `librime`?</b></summary><br/>
+#+html: <summary><b>Want a pure emacs input method without ~librime~?</b></summary><br/>
 
 Maybe, you need [[https://github.com/tumashu/pyim][pyim]].
 
 #+html: </details>
 
-#+html: </details>
-
 #+html: <details>
-#+html: <summary>How to integrate this with evil-escape?<summary>
+#+html: <summary><b>How to integrate this with ~evil-escape~?</b></summary>
 
 Add the following code snippet in your configuration files, then you can use [[https://github.com/syl20bnr/evil-escape][evil-escape]]
-to return to normal state. NOTE: this operation will abort all inserting content.
+to return to normal state when having nothing in editing(no preedit overlay).
 #+BEGIN_SRC emacs-lisp
-(defun rime-evil-escape-advice (orig-fun key)
-  "advice for `rime-input-method' to make it work together with `evil-escape'.
-Mainly modified from `evil-escape-pre-command-hook'"
-  (when (featurep 'evil-escape)
-    (let* (
-           (fkey (elt evil-escape-key-sequence 0))
-           (skey (elt evil-escape-key-sequence 1))
-           (evt (read-event nil nil evil-escape-delay))
-           )
-      (cond
-       ((and (characterp evt)
-             (or (and (char-equal key fkey) (char-equal evt skey))
-                 (and evil-escape-unordered-key-sequence
-                      (char-equal key skey) (char-equal evt fkey))))
-        (evil-repeat-stop)
-        ;; need 2 escape: one escapes from input method, the other one escapes from else
-        (rime--escape)
-        (evil-normal-state)
-        (let ((esc-fun (evil-escape-func)))
-              (when esc-fun
-                (setq this-command esc-fun)
-                (setq this-original-command esc-fun))))
-       ((null evt) (apply orig-fun (list key)))
-       (t
-        (apply orig-fun (list key))
-        (if (numberp evt)
-            (apply orig-fun (list evt))
-          (setq unread-command-events (append unread-command-events (list evt)))))))))
+  (defun rime-evil-escape-advice (orig-fun key)
+    "advice for `rime-input-method' to make it work together with `evil-escape'.
+	Mainly modified from `evil-escape-pre-command-hook'"
+    (if rime--preedit-overlay
+	;; if `rime--preedit-overlay' is non-nil, then we are editing something, do not abort 
+	(apply orig-fun (list key))
+      (when (featurep 'evil-escape)
+	(let* (
+	       (fkey (elt evil-escape-key-sequence 0))
+	       (skey (elt evil-escape-key-sequence 1))
+	       (evt (read-event nil nil evil-escape-delay))
+	       )
+	  (cond
+	   ((and (characterp evt)
+		 (or (and (char-equal key fkey) (char-equal evt skey))
+		     (and evil-escape-unordered-key-sequence
+			  (char-equal key skey) (char-equal evt fkey))))
+	    (evil-repeat-stop)
+	    (evil-normal-state))
+	   ((null evt) (apply orig-fun (list key)))
+	   (t
+	    (apply orig-fun (list key))
+	    (if (numberp evt)
+		(apply orig-fun (list evt))
+	      (setq unread-command-events (append unread-command-events (list evt))))))))))
 
-(advice-add 'rime-input-method :around #'rime-evil-escape-advice)
+  (advice-add 'rime-input-method :around #'rime-evil-escape-advice)
 #+END_SRC
 
 #+html: </details>


### PR DESCRIPTION
- 改进了#109 中提出的方案，原来的方案似乎会有轻微的卡顿。现在的方案不仅没有卡顿，也不会直接丢弃正在输入的内容了  （其实是之前没找到rime-preedit-overlay这个变量

- 同时修正了英文文档的一点格式问题。

- 甚至于，这个方案可以不依赖`evil-escape`，直接实现一个快速连击特定按键则回到normal state的功能。


- 目前的方案有个bug，如下图，我设置的键是jk:
![Screenshot_20200723_122938](https://user-images.githubusercontent.com/22413202/88252313-40324b80-cce0-11ea-8b03-146d614e248e.png)
jk在末尾，注意此时后面一串还都是英文，然后敲两次回车：
![Screenshot_20200723_123007](https://user-images.githubusercontent.com/22413202/88252322-504a2b00-cce0-11ea-87e1-d9681c14c9ed.png)
末尾的jk也会触发，然后就直接进入normal状态了。

  这个模式好像也不是inline-ascii？暂时没搞清楚怎么判断，不过应该也不影响使用（吧）
