### PR TITLE
add require('seq)

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -131,6 +131,7 @@
 
 ;;; Code:
 
+(require 'seq)
 (require 'subr-x)
 (require 'dash)
 (require 'cl-lib)


### PR DESCRIPTION
function seq-find need package seq.
try to manual installation will error: Symbol's function definition is void: seq-find
it should require package seq