### PR TITLE
fix problem with read-only state

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -694,12 +694,20 @@ By default the input-method will not handle DEL, so we need this command."
   (rime--inline-ascii)
   (rime--redisplay))
 
+(defun rime--text-read-only-p ()
+  "Return t if the text at point is read-only."
+  (and (or buffer-read-only
+           (get-char-property (point) 'read-only))
+       (not (or inhibit-read-only
+		(get-char-property (point) 'inhibit-read-only)))))
+
 (defun rime-input-method (key)
   "Process KEY with input method."
   (setq rime--current-input-key key)
   (when (rime--rime-lib-module-ready-p)
-    (if (and (not (rime--should-enable-p))
-             (not (rime--has-composition (rime-lib-get-context))))
+    (if (or (rime--text-read-only-p)
+            (and (not (rime--should-enable-p))
+                 (not (rime--has-composition (rime-lib-get-context)))))
         (list key)
       (let ((should-inline-ascii (rime--should-inline-ascii-p))
             (inline-ascii-prefix nil))


### PR DESCRIPTION
输入法切换到 rime 后，如果使用 `M-x view-mode` 或者 `C-x C-q` 使 buffer 进入只读状态，rime 仍然会继续处理按键，导致无法使用 view-mode。

采用 [quail-input-method](https://github.com/emacs-mirror/emacs/blob/master/lisp/international/quail.el#L1332) 的处理方式可以避免此问题。