### PR TITLE
restore input-method-function when deactivating rime

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -888,7 +888,8 @@ Argument NAME ignored."
   (rime--clear-state)
   (dolist (hook rime--hooks-for-clear-state)
     (remove-hook hook 'rime--clear-state t))
-  (rime-mode -1))
+  (rime-mode -1)
+  (kill-local-variable 'input-method-function))
 
 (defvar rime-active-mode-map
   (let ((keymap (make-sparse-keymap)))


### PR DESCRIPTION
一起使用 key-chord 和 rime 的时候出现如下问题：

1. 在 buffer 中 `M-x key-chord-mode` 启用 key-chord, 此时会将 input-method-function 设置为 key-chord-input-method

2. 然后使用 <kbd>C-\\</kbd> 切换到 rime 输入法，再 <kbd>C-\\</kbd> 关闭。此时 input-method-function 的值变为 nil，无法使用 key-chord-mode

参考 [quail-activate](https://github.com/emacs-mirror/emacs/blob/master/lisp/international/quail.el#L573)，input-method-function 的 buffer-local value 可以在退出 rime 时删掉，从而恢复默认值解决问题