### PR TITLE
allow <tab> in rime-translate-keybindings

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -752,6 +752,7 @@ By default the input-method will not handle DEL, so we need this command."
          (key (if (numberp key-raw)
                   key-raw
                 (cl-case key-raw
+                  (tab #xff09)
                   (home #xff50)
                   (left #xff51)
                   (up #xff52)


### PR DESCRIPTION
设置 `(add-to-list 'rime-translate-keybindings "<tab>")` 后，在 rime 中使用 <kbd>TAB</kbd> 会报错 "Can't send this keybinding to librime"，因此增加 tab 的 keysym value。