### PR TITLE
`emacs-module.h` for Fedora & Opensuse users

### DIFF
--- a/README.org
+++ b/README.org
@@ -353,7 +353,7 @@ Emacs Rime 已发布到 Melpa 。
 #+html: <details>
 #+html: <summary>如何获得支持动态模块的 Emacs</summary>
 **** Linux
-Linux 各主要发行版自带 emacs 默认已启用动态模块支持。
+Linux 各主要发行版自带 emacs 默认已启用动态模块支持。注：Fedora 需要安装  `emacs-devel`，OpenSUSE 需要安装 `emacs-el`。
 
 **** MacOS
 ***** emacs-plus 默认启用 ~--with-modules~ 选项，使用 homebrew 安装命令如下：

--- a/README.org
+++ b/README.org
@@ -30,6 +30,18 @@
   sudo apt install librime-dev
 #+end_src
 
+**** Fedora
+
+#+begin_src emacs-lisp
+  sudo dnf install librime-devel
+#+end_src
+
+**** openSUSE
+
+#+begin_src emacs-lisp
+  sudo zypper in librime-devel
+#+end_src
+
 请注意 ~librime-dev~ 的版本，如果在1.5.3以下，则需要自行编译。
 
 #+begin_src emacs-lisp


### PR DESCRIPTION
一点小小的更改。rpm 系的打包者们喜欢拆包，所以 emacs-module.h 被放到单独的包里面了。

https://github.com/DogLooksGood/emacs-rime/issues/141