### PR TITLE
do not override overriding-terminal-local-map in non-composition state

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -756,10 +756,11 @@ By default the input-method will not handle DEL, so we need this command."
   (when (rime--rime-lib-module-ready-p)
     (if (or (rime--text-read-only-p)
             (and (not rime-active-mode)
-                 overriding-terminal-local-map
-                 (or (not (eq (cadr overriding-terminal-local-map)
-                              universal-argument-map))
-                     (lookup-key overriding-terminal-local-map (vector key))))
+                 (or (and overriding-terminal-local-map
+                          (or (not (eq (cadr overriding-terminal-local-map)
+                                       universal-argument-map))
+                              (lookup-key overriding-terminal-local-map (vector key))))
+                     overriding-local-map))
             (and (not (rime--should-enable-p))
                  (not (rime--has-composition (rime-lib-get-context)))))
         (list key)

--- a/rime.el
+++ b/rime.el
@@ -755,6 +755,11 @@ By default the input-method will not handle DEL, so we need this command."
   (setq rime--current-input-key key)
   (when (rime--rime-lib-module-ready-p)
     (if (or (rime--text-read-only-p)
+            (and (not rime-active-mode)
+                 overriding-terminal-local-map
+                 (or (not (eq (cadr overriding-terminal-local-map)
+                              universal-argument-map))
+                     (lookup-key overriding-terminal-local-map (vector key))))
             (and (not (rime--should-enable-p))
                  (not (rime--has-composition (rime-lib-get-context)))))
         (list key)


### PR DESCRIPTION
`overriding-terminal-local-map`/`set-transient-map` 被一些package用于临时性地设置优先级最高的 keymap，包括 emacs-rime 在进入 composition 状态时也在使用。现在的问题在于 non-composition 状态下，即使设置了`overriding-*-local-map`，`rime-input-method` 仍然会处理按键。同时，这也不符合[文档](https://www.gnu.org/software/emacs/manual/html_node/elisp/Invoking-the-Input-Method.html)要求。

这个PR参考了 `quail-input-method`的处理方式。
