### PR TITLE
Add an option for sidewindow.

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,6 +70,8 @@
 
 设置 ~rime-sidewindow-style~ ，可选值有 ~top~, ~bottom~, ~left~, ~right~ ，分别指 sidewindow 出现的位置位于上下左右。
 
+设置 ~rime-sidewindow-keep-window~ ，为 ~t~ 时可保持 sidewindow 为开启状态。
+
 ** 设置软光标的样式
 
 默认使用 ~|~ 字符做为软光标，可以通过如下方式修改。

--- a/rime.el
+++ b/rime.el
@@ -202,6 +202,11 @@ Background and default foreground can be set in face `rime-default-face'."
   :options '(simple horizontal vertical)
   :group 'rime)
 
+(defcustom rime-sidewindow-keep-window nil
+  "Non-nil keep sidewindow open."
+  :type 'boolean
+  :group 'rime)
+
 (defcustom rime-sidewindow-side 'bottom
   "Side for sidewindow.
 
@@ -553,10 +558,13 @@ Currently just deactivate input method."
                  (window-height . fit-window-to-buffer)
                  (window-weight . fit-window-to-buffer)))))
         (with-current-buffer buffer
-          (when (string-blank-p content)
+          (when (and (string-blank-p content)
+                     (not rime-sidewindow-keep-window))
             (with-selected-window window
                                  (quit-window)))
           (erase-buffer)
+          (insert rime-title)
+          (insert " ")
           (insert content)
           (unless (derived-mode-p 'rime--candidate-mode)
             (rime--candidate-mode))))


### PR DESCRIPTION
This option can keep the sidewindow open, which can avoid annoying window raising and shrinking.

<img width="508" alt="Screen Shot 2021-06-19 at 04 21 15 PM" src="https://user-images.githubusercontent.com/5007613/122654575-7065b280-d11a-11eb-90d4-eb119894f827.png">
<img width="417" alt="Screen Shot 2021-06-19 at 04 21 21 PM" src="https://user-images.githubusercontent.com/5007613/122654576-7491d000-d11a-11eb-8ae2-920572e96ee3.png">


別慌，

兩个問題，一个是這个 sidewindow 和 minibuffer 一様，更換窗口時會被選中，不确定如何避免；另一个是，我現在不太确定應該如何突出這是屬于 rime 的 sidewindow，所以在左上角加了个 rime-title，可能加个背景顏色也不錯？