### PR TITLE
require xdg for xdg-data-dirs

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -137,6 +137,7 @@
 (require 'cl-lib)
 (require 'popup nil t)
 (require 'posframe nil t)
+(require 'xdg)
 
 (defconst rime-version "1.0.3")
 


### PR DESCRIPTION
Looks like these "xdg-" functions are not autoloaded, have to require
it explicitly.