### PR TITLE
更新README中对于evil-escape的处理方式

### DIFF
--- a/README.org
+++ b/README.org
@@ -404,29 +404,34 @@ patch:
 #+BEGIN_SRC emacs-lisp
   (defun rime-evil-escape-advice (orig-fun key)
     "advice for `rime-input-method' to make it work together with `evil-escape'.
-	Mainly modified from `evil-escape-pre-command-hook'"
+          Mainly modified from `evil-escape-pre-command-hook'"
     (if rime--preedit-overlay
-	;; if `rime--preedit-overlay' is non-nil, then we are editing something, do not abort
-	(apply orig-fun (list key))
+        ;; if `rime--preedit-overlay' is non-nil, then we are editing something, do not abort
+        (apply orig-fun (list key))
       (when (featurep 'evil-escape)
-	(let* (
-	       (fkey (elt evil-escape-key-sequence 0))
-	       (skey (elt evil-escape-key-sequence 1))
-	       (evt (read-event nil nil evil-escape-delay))
-	       )
-	  (cond
-	   ((and (characterp evt)
-		 (or (and (char-equal key fkey) (char-equal evt skey))
-		     (and evil-escape-unordered-key-sequence
-			  (char-equal key skey) (char-equal evt fkey))))
-	    (evil-repeat-stop)
-	    (evil-normal-state))
-	   ((null evt) (apply orig-fun (list key)))
-	   (t
-	    (apply orig-fun (list key))
-	    (if (numberp evt)
-		(apply orig-fun (list evt))
-	      (setq unread-command-events (append unread-command-events (list evt))))))))))
+        (let (
+              (fkey (elt evil-escape-key-sequence 0))
+              (skey (elt evil-escape-key-sequence 1))
+              )
+          (if (or (char-equal key fkey)
+                  (and evil-escape-unordered-key-sequence
+                       (char-equal key skey)))
+              (let ((evt (read-event nil nil evil-escape-delay)))
+                (cond
+                 ((and (characterp evt)
+                       (or (and (char-equal key fkey) (char-equal evt skey))
+                           (and evil-escape-unordered-key-sequence
+                                (char-equal key skey) (char-equal evt fkey))))
+                  (evil-repeat-stop)
+                  (evil-normal-state))
+                 ((null evt) (apply orig-fun (list key)))
+                 (t
+                  (apply orig-fun (list key))
+                  (if (numberp evt)
+                      (apply orig-fun (list evt))
+                    (setq unread-command-events (append unread-command-events (list evt))))))
+                )
+            (apply orig-fun (list key)))))))
 
   (advice-add 'rime-input-method :around #'rime-evil-escape-advice)
 #+END_SRC

--- a/README_EN.org
+++ b/README_EN.org
@@ -261,29 +261,35 @@ to return to normal state when having nothing in editing(no preedit overlay).
 #+BEGIN_SRC emacs-lisp
   (defun rime-evil-escape-advice (orig-fun key)
     "advice for `rime-input-method' to make it work together with `evil-escape'.
-	Mainly modified from `evil-escape-pre-command-hook'"
+          Mainly modified from `evil-escape-pre-command-hook'"
     (if rime--preedit-overlay
-	;; if `rime--preedit-overlay' is non-nil, then we are editing something, do not abort
-	(apply orig-fun (list key))
+        ;; if `rime--preedit-overlay' is non-nil, then we are editing something, do not abort
+        (apply orig-fun (list key))
       (when (featurep 'evil-escape)
-	(let* (
-	       (fkey (elt evil-escape-key-sequence 0))
-	       (skey (elt evil-escape-key-sequence 1))
-	       (evt (read-event nil nil evil-escape-delay))
-	       )
-	  (cond
-	   ((and (characterp evt)
-		 (or (and (char-equal key fkey) (char-equal evt skey))
-		     (and evil-escape-unordered-key-sequence
-			  (char-equal key skey) (char-equal evt fkey))))
-	    (evil-repeat-stop)
-	    (evil-normal-state))
-	   ((null evt) (apply orig-fun (list key)))
-	   (t
-	    (apply orig-fun (list key))
-	    (if (numberp evt)
-		(apply orig-fun (list evt))
-	      (setq unread-command-events (append unread-command-events (list evt))))))))))
+        (let (
+              (fkey (elt evil-escape-key-sequence 0))
+              (skey (elt evil-escape-key-sequence 1))
+              )
+          (if (or (char-equal key fkey)
+                  (and evil-escape-unordered-key-sequence
+                       (char-equal key skey)))
+              (let ((evt (read-event nil nil evil-escape-delay)))
+                (cond
+                 ((and (characterp evt)
+                       (or (and (char-equal key fkey) (char-equal evt skey))
+                           (and evil-escape-unordered-key-sequence
+                                (char-equal key skey) (char-equal evt fkey))))
+                  (evil-repeat-stop)
+                  (evil-normal-state))
+                 ((null evt) (apply orig-fun (list key)))
+                 (t
+                  (apply orig-fun (list key))
+                  (if (numberp evt)
+                      (apply orig-fun (list evt))
+                    (setq unread-command-events (append unread-command-events (list evt))))))
+                )
+            (apply orig-fun (list key)))))))
+
 
   (advice-add 'rime-input-method :around #'rime-evil-escape-advice)
 #+END_SRC


### PR DESCRIPTION
在之前的README的evil-escape处理时, 无论输入什么键的时候, 都会等待 `evil-escape-delay` 秒来判断是否组成 `evil-escape-key-sequence`.

这里改成了仅在可能构成的时候才等待下一个键. 这样可以有效解决输入标点符号和数字键时延迟的问题.

另外, 简单的测试中并未发现存在性能问题. 这样的简单判断似乎也不应该会造成性能问题.

想问一下 @dwuggh 添加‶存在性能问题″这句话的由来