### PR TITLE
Fix rime--message-display-content

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -465,11 +465,16 @@ Each keybinding in this list, will be bound to `rime-send-keybinding' in `rime-a
 
 (defun rime--message-display-content (content)
   "Display CONTENT via message."
-  (let ((message-log-max nil))
-    (save-window-excursion
+  (if (string-blank-p content)
+      (message "")
+    (let ((inhibit-quit t)
+          (message-log-max nil))
       (with-temp-message
           content
-        (sit-for most-positive-fixnum)))))
+        (sit-for most-positive-fixnum))
+      (when quit-flag
+        (setq quit-flag nil
+              unread-command-events '(7))))))
 
 (defun rime--popup-display-content (content)
   "Display CONTENT with popup.el."


### PR DESCRIPTION
fix [#203 ](https://github.com/DogLooksGood/emacs-rime/issues/203#issuecomment-1262985969)

在设置 `(setq rime-show-candidate 'message)` 后
> 输入一个汉字，按空格选定上屏之后 ( 此时 message 不再提示选字，回归输入汉字以前的状态 )，我需要再按下一个空格，或者按下右方向键，被输入的汉字才会显示出来。
> 
> 同样地，要删除这个显示出来的汉字，需要按两次 Backspace 键。

这个问题在 emacs 30 和 librime 1.8.5 下能够复现。参考 `rime--minibuffer-message` 的处理方式修改了一下 `rime--message-display-content`