### PR TITLE
Fix type of rime-disable-predicates

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -346,7 +346,7 @@ one of these functions return t, the input-method will toggle to inline mode."
   "A list of predicate functions, each receive no argument.
 
 If one of these functions return t, the input-method will fallback to ascii mode."
-  :type 'list
+  :type 'hook
   :group 'rime)
 
 (defcustom rime-show-candidate 'minibuffer


### PR DESCRIPTION
Without this change, calling

(setopt rime-disable-predicates
        (list #'rime-predicate-prog-in-code-p))

triggers this warning

Warning (emacs): Value ‘(rime-predicate-prog-in-code-p)’ does not match type list

because there is no 'list type[1].

[1]: info (elisp) Customization Types

Please not that there are other custom options with `'list` type.  I do not fix those because I have no interest in finding out a right type for them.