### PR TITLE
quote `rime-emacs-module-header-root` to avoid compile failure

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -1017,7 +1017,8 @@ You can customize the color with `rime-indicator-face' and `rime-indicator-dim-f
      (if rime-librime-root
          (format "LIBRIME_ROOT=%s" (file-name-as-directory (expand-file-name rime-librime-root))))
      (if rime-emacs-module-header-root
-         (format "EMACS_MODULE_HEADER_ROOT=%s" (file-name-as-directory (expand-file-name rime-emacs-module-header-root))))
+         (format "EMACS_MODULE_HEADER_ROOT=%s" (shell-quote-argument
+                                                (file-name-as-directory (expand-file-name rime-emacs-module-header-root)))))
      (format "MODULE_FILE_SUFFIX=%s" module-file-suffix))))
 
 (defun rime-compile-module ()


### PR DESCRIPTION
当 emacs 安装路径含有空格时，rime动态模块将编译失败。
``` shell
gcc lib.c -o librime-emacs.dll -fPIC -O2 -Wall -I c:/Users/shrubbroom/AppData/Roaming/.emacs.d/librime/dist-msvc/dist/include/ -I c:/Program Files/Emacs/emacs-29.3_2/include/ -shared -L c:/Users/shrubbroom/AppData/Roaming/.emacs.d/librime/dist-msvc/dist/lib/ -Wl,-rpath c:/Users/shrubbroom/AppData/Roaming/.emacs.d/librime/dist-msvc/dist/lib/ -lrime
lib.c:23:10: fatal error: emacs-module.h: No such file or directory
   23 | #include <emacs-module.h>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
```
此类情况需要将路径 quote 以避免编译失败。
``` shell
gcc lib.c -o librime-emacs.dll -fPIC -O2 -Wall -I c:/Users/shrubbroom/AppData/Roaming/.emacs.d/librime/dist-msvc/dist/include/ -I "c:/Program Files/Emacs/emacs-29.3_2/include/" -shared -L c:/Users/shrubbroom/AppData/Roaming/.emacs.d/librime/dist-msvc/dist/lib/ -Wl,-rpath c:/Users/shrubbroom/AppData/Roaming/.emacs.d/librime/dist-msvc/dist/lib/ -lrime
```
PTAL.