### PR TITLE
Check if posframe workable via `posframe-workable-p`

### DIFF
--- a/rime.el
+++ b/rime.el
@@ -537,7 +537,7 @@ Currently just deactivate input method."
 
 (defun rime--posframe-display-content (content)
   "Display CONTENT with posframe."
-  (if (and (featurep 'posframe) (display-graphic-p))
+  (if (and (featurep 'posframe) (posframe-workable-p))
       (if (string-blank-p content)
           (posframe-hide rime-posframe-buffer)
         (let*


### PR DESCRIPTION
This makes rime uses posframe in TTY when tty-child-frames feature is enabled.

tty-child-frame is supported by posframe since:
[a31476cbe0df3cfffad7efeda84700a13d7ebc01](https://github.com/tumashu/posframe/commit/a31476cbe0df3cfffad7efeda84700a13d7ebc01)